### PR TITLE
Fixes end truncate behavior

### DIFF
--- a/test.js
+++ b/test.js
@@ -122,4 +122,13 @@ describe('truncate', function() {
     expect = '<p><div>hel---WHATEVER-I-WANT</div></p>';
     assert.strictEqual(expect, actual);
   });
+
+  it('should append ellipsis if the string has been shortened', function() {
+    var input, expect, actual;
+
+    input  = 'thisare19characters <a href="http://google.com">http://google.com</a>';
+    actual = truncate(input, 33);
+    expect = 'thisare19characters <a href="http://google.com">http://google...</a>';
+    assert.strictEqual(expect, actual);
+  });
 });

--- a/truncate.js
+++ b/truncate.js
@@ -163,7 +163,7 @@
             string = string.substring(index + result.length);
         }
 
-        if (string.length > maxLength && options.ellipsis) {
+        if (string.length > maxLength - total && options.ellipsis) {
             content += options.ellipsis;
         }
         content += _dumpCloseTag(items);


### PR DESCRIPTION
The issue seems to be from the line:

```javascript
            if (total + index > maxLength) {
                // exceed given `maxLength`, dump everything to clear stack
                content += (string.substring(0, maxLength - total));
```

If the "dump everything" happens then it doesn't add an ellipsis

I used the example from #9 for the unit test, thanks @GriffinHeart