### PR TITLE
Handle single quotes in attr regex

### DIFF
--- a/lib/truncate.js
+++ b/lib/truncate.js
@@ -20,7 +20,7 @@ function truncate(string, maxLength, options) {
         items = [],                     // stack for saving tags
         total = 0,                      // record how many characters we traced so far
         content = EMPTY_STRING,         // truncated text storage
-        KEY_VALUE_REGEX = '([\\w|-]+\\s*=\\s*"[^"]*"\\s*)*',
+        KEY_VALUE_REGEX = '([\\w|-]+\\s*=\\s*["\'][^"]*["\']\\s*)*',
         IS_CLOSE_REGEX = '\\s*\\/?\\s*',
         CLOSE_REGEX = '\\s*\\/\\s*',
         SELF_CLOSE_REGEX = new RegExp('<\\/?\\w+\\s*' + KEY_VALUE_REGEX + CLOSE_REGEX + '>'),

--- a/test.js
+++ b/test.js
@@ -202,4 +202,14 @@ describe('truncate', function() {
     expect = 'thisare19characters <a href="http://google.com">http://google...</a>';
     assert.strictEqual(expect, actual);
   });
+
+  it('should handle single quotes in attributes', function() {
+    var input, expect, actual;
+
+    input  = "hello <a href='http://google.com'>world</a>";
+    actual = truncate(input, 8);
+    expect = "hello <a href='http://google.com'>wo...</a>";
+    assert.strictEqual(expect, actual);
+  });
+
 });


### PR DESCRIPTION
This allows using single quotes e.g. `<a href='http://google.com'>Google</a>`. 