### PR TITLE
Revert PR #16 commit Handle attributes with no values.

### DIFF
--- a/lib/truncate.js
+++ b/lib/truncate.js
@@ -20,7 +20,7 @@ function truncate(string, maxLength, options) {
         items = [],                     // stack for saving tags
         total = 0,                      // record how many characters we traced so far
         content = EMPTY_STRING,         // truncated text storage
-        KEY_VALUE_REGEX = '([\\w|-]+\\s*(=\\s*"[^"]*")?\\s*)*',
+        KEY_VALUE_REGEX = '([\\w|-]+\\s*=\\s*"[^"]*"\\s*)*',
         IS_CLOSE_REGEX = '\\s*\\/?\\s*',
         CLOSE_REGEX = '\\s*\\/\\s*',
         SELF_CLOSE_REGEX = new RegExp('<\\/?\\w+\\s*' + KEY_VALUE_REGEX + CLOSE_REGEX + '>'),

--- a/test.js
+++ b/test.js
@@ -203,13 +203,4 @@ describe('truncate', function() {
     assert.strictEqual(expect, actual);
   });
 
-  it('should handle attributes with no values', function() {
-    var input, expect, actual;
-
-    input  = 'hello<iframe src="//youtube.com" allowfullscreen></iframe>world';
-    actual = truncate(input, 8);
-    expect = 'hello<iframe src="//youtube.com" allowfullscreen></iframe>wor...';
-    assert.strictEqual(expect, actual);
-  });
-
 });


### PR DESCRIPTION
As this issue informs https://github.com/huang47/nodejs-html-truncate/issues/24 the PR #16 introduces a bug that frozes the browser so I think would be useful revert this change.